### PR TITLE
Honoring distributed flag + fixing reset_classifier

### DIFF
--- a/main.py
+++ b/main.py
@@ -295,7 +295,7 @@ def main(args):
             max_accuracy = checkpoint['max_accuracy']
 
     if args.eval:
-        test_stats = evaluate(data_loader_val, model, device, num_tasks, distributed=True, amp=args.amp)
+        test_stats = evaluate(data_loader_val, model, device, num_tasks, distributed=args.distributed, amp=args.amp)
         print(f"Accuracy of the network on the {len(dataset_val)} test images: {test_stats['acc1']:.2f}%")
         return
 
@@ -316,7 +316,7 @@ def main(args):
 
         lr_scheduler.step(epoch)
 
-        test_stats = evaluate(data_loader_val, model, device, num_tasks, distributed=True, amp=args.amp)
+        test_stats = evaluate(data_loader_val, model, device, num_tasks, distributed=args.distributed, amp=args.amp)
         print(f"Accuracy of the network on the {len(dataset_val)} test images: {test_stats['acc1']:.2f}%")
         max_accuracy = max(max_accuracy, test_stats["acc1"])
         print(f'Max accuracy: {max_accuracy:.2f}%')

--- a/models/crossvit.py
+++ b/models/crossvit.py
@@ -211,6 +211,7 @@ class VisionTransformer(nn.Module):
         super().__init__()
 
         self.num_classes = num_classes
+        self.embed_dim = embed_dim
         if not isinstance(img_size, list):
             img_size = to_2tuple(img_size)
         self.img_size = img_size
@@ -281,7 +282,7 @@ class VisionTransformer(nn.Module):
 
     def reset_classifier(self, num_classes, global_pool=''):
         self.num_classes = num_classes
-        self.head = nn.Linear(self.embed_dim, num_classes) if num_classes > 0 else nn.Identity()
+        self.head = nn.ModuleList([nn.Linear(self.embed_dim[i], num_classes) if num_classes > 0 else nn.Identity() for i in range(self.num_branches)])
 
     def forward_features(self, x):
         B, C, H, W = x.shape


### PR DESCRIPTION
1. Honoring the args.distributed flag in calls to evaluate().
2. A couple of changes to make the reset_classifier() method work:
  - Initializing the embed_dim instance variable in VisionTransformer.
  - Reinitializing the classification head for all branches.
